### PR TITLE
feat: fetch ogp description metadata and display below medium articles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -61,6 +61,12 @@ const gitcoinServerOptions = {
   }
 };
 
+const mediumPostsServerOptions = {
+  name: `mediumPosts`,
+  ...lambdaServerDefaults("getMediumPosts"),
+  verboseOutput: true
+};
+
 module.exports = {
   siteMetadata: {
     title: `Centrifuge`,
@@ -111,17 +117,7 @@ module.exports = {
     },
     {
       resolve: "gatsby-source-apiserver",
-      options: {
-        name: "mediumPosts",
-        typePrefix: "rss2json__",
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        url:
-          "https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fcentrifuge%2F",
-        verboseOutput: true
-      }
+      options: mediumPostsServerOptions
     },
     {
       resolve: "gatsby-source-contentful",

--- a/lambda/getMediumPosts.js
+++ b/lambda/getMediumPosts.js
@@ -1,0 +1,49 @@
+import fetch from "node-fetch";
+import cheerio from "cheerio";
+
+const unescapeSpecialChars = str => {
+  return cheerio.load(`<!doctype html><body>${str}</body>`, "text/html").text();
+};
+
+exports.handler = async (event, context) => {
+  const RSS2JSON_ENDPOINT = `https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fcentrifuge%2F`;
+
+  var responseJson;
+  try {
+    const response = await fetch(RSS2JSON_ENDPOINT);
+    responseJson = await response.json();
+  } catch (error) {
+    return {
+      statusCode: 422,
+      body: JSON.stringify(error)
+    };
+  }
+
+  const mediumPosts = { items: [] };
+  for (let item of responseJson.items) {
+    try {
+      item.title = unescapeSpecialChars(item.title);
+
+      let articleResponse = await fetch(item.link);
+      let articleHTML = await articleResponse.text();
+      let $ = cheerio.load(articleHTML);
+
+      let _description = $(`meta[property="og:description"]`).attr(`content`);
+      let _image = $(`meta[property="og:image"]`).attr(`content`);
+
+      if (_description) {
+        item.description = _description;
+      }
+      if (_image) {
+        item.thumbnail = _image;
+      }
+    } finally {
+      mediumPosts.items.push(item);
+    }
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(mediumPosts)
+  };
+};

--- a/src/components/News/index.js
+++ b/src/components/News/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Heading, Paragraph, Image, Box, Button } from "grommet";
 import styled from "styled-components";
 
@@ -22,11 +22,32 @@ const ImageWrapper = styled.div`
   }
 `;
 
-const LinkedMediumImage = ({ imageId, slug }) => (
+const LinkedMediumImage = ({ imageId, slug, highlight }) => (
   <ExternalLink href={slug}>
-    <ImageWrapper>
+    <ImageWrapper
+      style={
+        !highlight
+          ? {
+              width: "100%",
+              paddingTop: "50%",
+              margin: "0",
+              overflow: "hidden"
+            }
+          : {}
+      }
+    >
       <Image
-        style={{ maxWidth: "100%", verticalAlign: "middle" }}
+        style={
+          !highlight
+            ? {
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                width: "100%"
+              }
+            : { maxWidth: "100%", verticalAlign: "middle" }
+        }
         src={imageId}
       />
     </ImageWrapper>
@@ -68,20 +89,24 @@ const MediumPost = ({ post }) => (
     <Box margin={{ bottom: "medium" }}>
       <LinkedMediumImage imageId={post.thumbnail} slug={post.link} />
     </Box>
-    <PostInfo title={post.title} subtitle={""} link={post.link} heading="3" />
+    <PostInfo title={post.title} subtitle={post.description} link={post.link} heading="3" />
   </>
 );
 
 const HighlightPost = ({ post }) => (
-  <Grid align="start" mt="">
+  <Grid align="start">
     <Column span={{ medium: 10, large: 6 }}>
       <Box margin={{ bottom: "medium" }}>
-        <LinkedMediumImage imageId={post.thumbnail} slug={post.link} />
+        <LinkedMediumImage
+          highlight
+          imageId={post.thumbnail}
+          slug={post.link}
+        />
       </Box>
     </Column>
     <Spacer width={2} />
     <Column span={{ medium: 10, large: 4 }}>
-      <PostInfo title={post.title} subtitle={""} link={post.link} />
+      <PostInfo title={post.title} subtitle={post.description} link={post.link} />
     </Column>
   </Grid>
 );

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -48,8 +48,10 @@ const NewsPage = ({ data }) => {
 
   const page = data.allContentfulPageNews.edges[0].node;
 
-  const mediumPosts = data.mediumFeed.posts.slice(0, 4);
-  const highlightPost = data.mediumFeed.posts[0];
+  const mediumPosts = data.mediumFeed.items.slice(0, 4);
+  const highlightPost = data.mediumFeed.items[0];
+
+  console.log(mediumPosts, highlightPost);
 
   return (
     <Layout>
@@ -185,12 +187,12 @@ export const NewsPageQuery = graphql`
       }
     }
 
-    mediumFeed: rss2JsonMediumPosts {
-      posts: items {
+    mediumFeed: lambdaMediumPosts {
+      items {
         title
-        link
-        thumbnail
         description
+        thumbnail
+        link
       }
     }
   }


### PR DESCRIPTION
fixes #161 

### Description

- fetch description from ogp metadata on medium pages and display them below articles
- also unescape html special characters like `&amp;`

### Screenshot (updated)

<img width="1173" alt="Screenshot 2020-03-07 at 11 54 37 PM" src="https://user-images.githubusercontent.com/22390515/76150311-0e24a200-60cf-11ea-8461-0326d6b68c05.png">
