### PR TITLE
update links to new docs

### DIFF
--- a/content/faqs.yaml
+++ b/content/faqs.yaml
@@ -20,7 +20,7 @@
     - q: SPV
       a: Special Purpose Vehicle - a legal entity created to fulfill narrow, specific or temporary objectives. Typically used by companies to isolate the firm from financial risk. In Centrifuge, SPVs enforce that legal recourse is available to holders of DROP and TIN.
     - q: DROP & TIN
-      a: md// Based on each NFT pool, ERC20 tokens (TIN and DROP) are minted. These two tokens represent the underlying collateral. DROP is the Senior token with a fixed interest rate and stable returns, loss protected by TIN. TIN is the Junior token with higher yield and risk; takes loss first. You can read more [here](https://developer.centrifuge.io/tinlake/overview/tranches/).
+      a: md// Based on each NFT pool, ERC20 tokens (TIN and DROP) are minted. These two tokens represent the underlying collateral. DROP is the Senior token with a fixed interest rate and stable returns, loss protected by TIN. TIN is the Junior token with higher yield and risk; takes loss first. You can read more [here](https://docs.centrifuge.io/tinlake/overview/tranches/).
     - q: NFT
       a: md// **Non-Fungible Token** as a digital representation of a single unique collateral, IE one invoice. The Centrifuge business NFT follows the [ERC-/EIP-721 Ethereum standard](https://eips.ethereum.org/EIPS/eip-721).
     - q: Revolving Pool
@@ -69,7 +69,7 @@
     - q: Can I transfer my DROP token?
       a: Technically DROP tokens can be transferred similar to other ERC20 tokens. However, due to their security status, their transfer is restricted to other whitelisted addresses only. If you want to transfer your DROP to another one of your addresses, please get in touch to get it whitelisted.
     - q: Can you explain Centrifuge’s token structure? I see CFG, TIN and DROP. Why are there three tokens?
-      a: md// The CFG token powers Centrifuge Chain and Protocol. TIN and DROP are used in Tinlake, a dApp running on Centrifuge. Please find more information on our CFG token [here](https://centrifuge.io/products/chain/) and on Tinlake’s TIN and DROP [here](https://developer.centrifuge.io/tinlake/overview/tranches/).
+      a: md// The CFG token powers Centrifuge Chain and Protocol. TIN and DROP are used in Tinlake, a dApp running on Centrifuge. Please find more information on our CFG token [here](https://centrifuge.io/products/chain/) and on Tinlake’s TIN and DROP [here](https://docs.centrifuge.io/tinlake/overview/tranches/).
     - q: Is TIN available for investors?
       a: Our Asset Originators have only opened TIN to a small number of institutional investors who have been instrumental in developing their product. We anticipate that in the future some Asset Originators will choose to make TIN more widely available to investors.
 
@@ -92,7 +92,7 @@
     - q: What is the collateralization level on the NFT portfolio relative to the loan amount? 
       a: That depends on the asset class, e.g. if you buy a home in the US you can get as low as 10% of down payment, sometimes 20%. That eventually translates down to the collateralization rate. For supply chain finance with invoices as an asset you usually have a 80% advance rate as industry standard, sometimes up to 100%. That would be the collateralization ratio for invoice NFTs. One important part to keep in mind, the Tinlake smart contracts are intended to be deployed for each individual asset class with specific parameters.
     - q: How is a pool priced? Both at an initial issuance and later during the pool's life? 
-      a: md// There is no generic answer to what a pricing oracle looks like in particular. We built Tinlake with both crypto native and real-world assets in mind; these assets are priced very differently. For example, a house is priced very differently from an invoice, which is priced very differently from ETH. When setting up the pool, the Asset Originator who wants to create the pool will work with data sources that exist today, such as underwriters, risk modelers, fraud prevention companies in order to build the safest oracle for that pool. You can read more about pricing real-world assets [here.] (https://developer.centrifuge.io/tinlake/overview/pricing_rwa/) 
+      a: md// There is no generic answer to what a pricing oracle looks like in particular. We built Tinlake with both crypto native and real-world assets in mind; these assets are priced very differently. For example, a house is priced very differently from an invoice, which is priced very differently from ETH. When setting up the pool, the Asset Originator who wants to create the pool will work with data sources that exist today, such as underwriters, risk modelers, fraud prevention companies in order to build the safest oracle for that pool. You can read more about pricing real-world assets [here.] (https://docs.centrifuge.io/tinlake/overview/pricing_rwa/) 
 
 - title: About Centrifuge
   faqs:

--- a/src/components/Footer/footerItem.js
+++ b/src/components/Footer/footerItem.js
@@ -44,7 +44,7 @@ const BlockExternalLink = () => (
           <FooterExternalLinkItem href="https://github.com/centrifuge/">
             GitHub
           </FooterExternalLinkItem>
-          <FooterExternalLinkItem href="https://developer.centrifuge.io/">
+          <FooterExternalLinkItem href="https://docs.centrifuge.io/">
             Documentation
           </FooterExternalLinkItem>
           <FooterExternalLinkItem href="https://gov.centrifuge.io/">

--- a/src/components/SocialButtons/index.js
+++ b/src/components/SocialButtons/index.js
@@ -85,7 +85,7 @@ const DevDocsButton = ({ width }) => (
     label="Developer Docs"
     description="Read documentation."
     icon={<Book width="100%" />}
-    href="https://developer.centrifuge.io/"
+    href="https://docs.centrifuge.io/"
     width={width}
   />
 );


### PR DESCRIPTION
the links in faqs.yaml redirect to non-existed docs.centrifuge pages. (probably inprogress)
-https://developer.centrifuge.io/tinlake/overview/tranches/   => https://docs.centrifuge.io/learn/understanding-tinlake/#drop--tin-the-two-tranches
-https://developer.centrifuge.io/tinlake/overview/pricing_rwa/ => https://docs.centrifuge.io/learn/understanding-tinlake/#asset-pricing