### PR TITLE
chore: update readme with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,18 @@ This repo builds the centrifuge.io website with Gatsby and Netlify.
 
 ### Getting Started
 
+> NodeJS v16+ and Yarn are required to run this project.
+
 ```sh
 # install dependencies
-npm install
+yarn
 
 # starts lambda and gatsby servers
-npm run start
+yarn start
 ```
 
 ## MDX Pages
+
 To see what layout elements are available on MDX pages, launch the site in dev mode and go to `/mdxguide/`
 
 ## Gotchas
@@ -26,6 +29,12 @@ To see what layout elements are available on MDX pages, launch the site in dev m
 When adding a new lambda function to work on a feature, the lambda must be merged into `develop` and then to `master` before any usage of of the lambda function is implemented. This is due to during the `gatsby build` step the lambda functions are called to pull in data, since the function is not callable the build completes and passes, its not avaiable during the build step.
 
 Once your lambda function has been merged into `develop` and `master` then its okay to use the function during the build step.
+
+Building the website requires setting the environment variable `URL` to the production URL of the website.
+
+```sh
+URL=https://centrifuge.io yarn build
+```
 
 ### Managing pictures
 


### PR DESCRIPTION
This PR updates readme README with special instructions needed to build the website locally, reflecting the need for Yarn when installing dependencies.