### PR TITLE
fix: show loading indicator for the job listing

### DIFF
--- a/src/components/Jobs/index.js
+++ b/src/components/Jobs/index.js
@@ -15,7 +15,11 @@ export function useLeverPostings(site) {
 }
 
 const Jobs = () => {
-  const jobs = useLeverPostings("centrifuge") ?? [];
+  const jobs = useLeverPostings("centrifuge");
+
+  if (jobs === undefined) {
+    return <p>Loading...</p>;
+  }
 
   if (jobs.length === 0) {
     return <p>There are no open positions at this time.</p>;


### PR DESCRIPTION
Currently, the job listing shows "There are no open positions at this time." while the jobs are loading.

This PR adds a loading indicator ("Loading...") which will be displayed until the request finishes. 