### PR TITLE
chore: remove migration banner

### DIFF
--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -23,7 +23,7 @@ const Layout = ({ dark, children, location }) => {
     <Theme>
       <ThemeContext.Extend value={{ dark }}>
         <Navigation dark={dark} />
-        <CrossPageBanner />
+        {/* <CrossPageBanner /> */}
         <main>{children}</main>
         {showEmailSubscription(location?.pathname) && <EmailSubscription />}
         <Footer />


### PR DESCRIPTION
### Description

This pull request removes the banner at the top of the website about CFG transfer downtime.

<img width="770" alt="image" src="https://user-images.githubusercontent.com/28536523/175655520-c7e75803-85f2-4b17-8770-29e024c1243f.png">
