### PR TITLE
chore: add `X-frame-Options: DENY` to netlify headers file

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,3 @@
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block


### PR DESCRIPTION
This prevents embedding the website in an iframe, which is a security risk.

![image](https://user-images.githubusercontent.com/2014259/178546985-d1e5aa3b-56fd-4c8b-af7a-fffc1da1777d.png)

References:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
- https://www.owasp.org/index.php/Clickjacking
- https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Clickjacking_Defense_Cheat_Sheet.md