### PR TITLE
Global layout

### DIFF
--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -15,6 +15,23 @@ export const GlobalStyle = createGlobalStyle`
     -moz-osx-font-smoothing: grayscale;
   }
 
+  #gatsby-focus-wrapper {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;  
+  }
+
+  @supports (min-height: 100dvh) {
+    #gatsby-focus-wrapper {
+      min-height: 100dvh;
+    }
+  }
+
+  #gatsby-focus-wrapper > * {
+    min-width: 0;
+    width: 100%;
+  }
+
   body {
     font-family: Inter, sans-serif;
   }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { GlobalStyle as FabricGlobalStyle } from '@centrifuge/fabric'
 import * as React from 'react'
 import { ThemeProvider } from 'styled-components'
+import { Box } from '@centrifuge/fabric'
 import { theme } from '../theme'
 import { Footer } from './footer'
 import { GlobalStyle } from './GlobalStyle'
@@ -16,7 +17,9 @@ export function Layout({ children }: LayoutProps) {
       <FabricGlobalStyle />
       <GlobalStyle />
       <Header />
-      <main>{children}</main>
+      <Box as="main" pt={theme.sizes.headerHeight} flexGrow={2}>
+        {children}
+      </Box>
       <Footer />
     </ThemeProvider>
   )


### PR DESCRIPTION
Changes:
- make sure the main container (`#gatsby-focus-wrapper`) spans over the whole available window height
- make `main` take up available space and push footer to bottom of window

Ticket:
https://app.zenhub.com/workspaces/centrifuge-applications-5fa29e924059e5001625e2a3/issues/centrifuge/website/510