### PR TITLE
Update discord link

### DIFF
--- a/config/links.ts
+++ b/config/links.ts
@@ -2,7 +2,7 @@ export const links = {
   twitter: 'https://twitter.com/centrifuge',
   telegram: 'https://t.me/centrifuge_chat',
   medium: 'https://medium.com/centrifuge',
-  discord: 'https://centrifuge.io/discord',
+  discord: 'https://discord.com/invite/yEzyUq5gxF',
   youtube: 'https://www.youtube.com/channel/UCfNkoq7YLrr8MeSJ3a6jVcA',
   github: 'https://github.com/centrifuge/',
   linkedin: 'https://www.linkedin.com/company/centrifugehq/',


### PR DESCRIPTION
Fixes `Discord` 404 page. Now points to https://discord.com/invite/yEzyUq5gxF