### PR TITLE
Not fail when the PR branch has been deleted before the job runs

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -28,24 +28,26 @@ jobs:
 
     environment: gcloud-dev      
     steps:
+    # Assume a PR won't be closed unless the deployments are finished
+    # because this wait functions will fail if developers delete the branch
+    # before this wait-on-check-action run (30s-2min)
+      # - name: wait for function-deploy jobs to finish
+      #   uses: lewagon/wait-on-check-action@v1.2.0
+      #   continue-on-error: true
+      #   with:
+      #     ref: ${{ github.head_ref || github.ref }}
+      #     check-name: 'deploy-functions'
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     wait-interval: 10
 
-      - name: wait for function-deploy jobs to finish
-        uses: lewagon/wait-on-check-action@v1.2.0
-        continue-on-error: true
-        with:
-          ref: ${{ github.head_ref || github.ref }}
-          check-name: 'deploy-functions'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-
-      - name: wait for web-deploy jobs to finish
-        uses: lewagon/wait-on-check-action@v1.2.0
-        continue-on-error: true
-        with:
-          ref: ${{ github.head_ref || github.ref }}
-          check-name: 'publish-to-gcs'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10          
+      # - name: wait for web-deploy jobs to finish
+      #   uses: lewagon/wait-on-check-action@v1.2.0
+      #   continue-on-error: true
+      #   with:
+      #     ref: ${{ github.head_ref || github.ref }}
+      #     check-name: 'publish-to-gcs'
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     wait-interval: 10          
       
       - name: Auth gcloud
         id: gauth

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: wait for function-deploy jobs to finish
         uses: lewagon/wait-on-check-action@v1.2.0
+        continue-on-error: true
         with:
           ref: ${{ github.head_ref || github.ref }}
           check-name: 'deploy-functions'
@@ -39,6 +40,7 @@ jobs:
 
       - name: wait for web-deploy jobs to finish
         uses: lewagon/wait-on-check-action@v1.2.0
+        continue-on-error: true
         with:
           ref: ${{ github.head_ref || github.ref }}
           check-name: 'publish-to-gcs'

--- a/.github/workflows/functions-countercheck.yml
+++ b/.github/workflows/functions-countercheck.yml
@@ -1,0 +1,12 @@
+name: Functions
+on:
+  pull_request:
+    paths-ignore:
+      - 'functions/**'
+      - '.github/workflows/functions.yml'
+jobs:
+  deploy-functions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+        echo "This job is always green to ensure PRs without code changes to the main folders can also merge"

--- a/.github/workflows/functions-countercheck.yml
+++ b/.github/workflows/functions-countercheck.yml
@@ -8,5 +8,4 @@ jobs:
   deploy-functions:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-        echo "This job is always green to ensure PRs without code changes to the main folders can also merge"
+      - run: 'echo "This job is always green to ensure PRs without code changes to the main folders can also merge"'


### PR DESCRIPTION
Fix the scenario where the branch from the PR has been deleted and the PR job is trying to find it to see if any deployments are still running.
Corner case: I open a PR and close it so quickly that the deploy job will run "after" the PR close job and the function+bucket will remain in Gcloud.