### PR TITLE
Restructure main navigation

### DIFF
--- a/config/menu.ts
+++ b/config/menu.ts
@@ -10,12 +10,17 @@ const menu = [
     href: '/news',
   },
   {
-    label: 'Governance',
-    href: '/governance',
-  },
-  {
     label: 'About',
-    href: '/about',
+    items: [
+      {
+        label: 'Contributors',
+        href: '/contributors',
+      },
+      {
+        label: 'Governance',
+        href: '/governance',
+      },
+    ],
   },
   {
     label: 'Community',

--- a/src/pages/contributors.tsx
+++ b/src/pages/contributors.tsx
@@ -1,11 +1,9 @@
-import { AnchorButton, Stack } from '@centrifuge/fabric'
+import { Stack } from '@centrifuge/fabric'
 import type { HeadProps } from 'gatsby'
 import { graphql } from 'gatsby'
 import * as React from 'react'
-import { useLeverPositions } from '../hooks/use-lever-positions'
 import { BeliefsSection, BeliefsSectionProps } from '../components/BeliefsSection'
 import { ContributorsSection, ContributorsSectionProps } from '../components/contributors-section'
-import { HeroVideo, HeroVideoProps } from '../components/HeroVideo'
 import { Layout } from '../components/Layout'
 import { OrgSection, OrgSectionProps } from '../components/OrgSection'
 import { SEO, SEOProps } from '../components/Seo'
@@ -19,10 +17,6 @@ export const query = graphql`
 
       seo {
         ...SeoFragment
-      }
-
-      hero_video {
-        ...HeroVideoFragment
       }
 
       maker_section {
@@ -52,7 +46,6 @@ type ContributorsProps = {
   data: {
     dataJson: {
       seo: SEOProps
-      hero_video: HeroVideoProps
       maker_section: MakerSectionProps
       org_section: OrgSectionProps
       beliefs_section: BeliefsSectionProps
@@ -63,21 +56,12 @@ type ContributorsProps = {
 }
 
 export default function Contributors({ data }: ContributorsProps) {
-  const { positions } = useLeverPositions()
   const careersId = 'careers'
-  const { hero_video, maker_section, org_section, beliefs_section, contributors_section, career_section } =
-    data.dataJson
+  const { maker_section, org_section, beliefs_section, contributors_section, career_section } = data.dataJson
 
   return (
     <Layout>
-      <Stack gap="layoutLarge">
-        <HeroVideo {...hero_video}>
-          {!!positions?.length && (
-            <AnchorButton href={`#${careersId}`} variant="secondary">
-              We are hiring 🚀
-            </AnchorButton>
-          )}
-        </HeroVideo>
+      <Stack gap="layoutLarge" mt={[2, 4, 6]}>
         <MakerSection {...maker_section} />
         <ContributorsSection {...contributors_section} />
         <OrgSection {...org_section} />


### PR DESCRIPTION
- renames 'about' to 'contributors'
- removes hero-video from page